### PR TITLE
Make summernote options extendable

### DIFF
--- a/lib/template/template.html
+++ b/lib/template/template.html
@@ -1,5 +1,5 @@
 <template name="orionAttributesSummernote">
-	<div class="orionSummernote" {{ this.atts }}>
+	<div class="orionSummernote" {{ atts }}>
 		<div class="progress progress-striped active">
 			<div class="progress-bar"></div>
 		</div>

--- a/lib/template/template.js
+++ b/lib/template/template.js
@@ -2,7 +2,7 @@ Template.orionAttributesSummernote.rendered = function () {
     var key = this.data.name;
     var parent = $('[data-schema-key="' + key + '"]')
     var element = parent.find('.summernote');
-    element.summernote({
+    var options = _.extend({
         height: 300,
         onImageUpload: function(files, editor, $editable) {
             parent.find('.progress').show();
@@ -15,9 +15,20 @@ Template.orionAttributesSummernote.rendered = function () {
                 parent.find('.progress').hide();
             });
         }
-    });
+    }, this.data.atts.summernoteOptions);
+    element.summernote(options);
     element.code(this.data.value);
 };
+
+Template.orionAttributesSummernote.helpers({
+    atts: function afSelectAtts() {
+        var atts = _.clone(this.atts);
+
+        // Remove summernote options from atts as they cannot necessarily be stringified
+        delete atts.summernoteOptions;
+        return atts;
+    }
+})
 
 Template.orionAttributesSummernoteColumn.helpers({
     preview: function () {


### PR DESCRIPTION
For instance, the summernote toolbar can now be customized from the schema, such as:

    body: orion.attribute('summernote', {
      label: 'Body',
      optional: true,
      autoform: {
        summernoteOptions: {
          toolbar: [
            ['style', ['bold', 'italic', 'underline', 'clear']],
            ['para', ['ul', 'ol', 'paragraph']],
            ['insert', ['link']]
          ]
        }
      }
    })